### PR TITLE
Add Openshift template

### DIFF
--- a/.openshiftio/application.yml
+++ b/.openshiftio/application.yml
@@ -1,0 +1,136 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: github-cleanup
+  annotations:
+    description: This template creates a Build Configuration using an S2I builder.
+    tags: instant-app
+parameters:
+  - name: SOURCE_REPOSITORY_URL
+    description: The source URL for the application
+    displayName: Source URL
+    required: true
+  - name: SOURCE_REPOSITORY_REF
+    description: The branch name for the application
+    displayName: Source Branch
+    value: master
+    required: true
+  - name: SOURCE_REPOSITORY_DIR
+    description: The location within the source repo of the application
+    displayName: Source Directory
+    value: .
+    required: true
+  - name: GITHUB_WEBHOOK_SECRET
+    description: A secret string used to configure the GitHub webhook.
+    displayName: GitHub Webhook Secret
+    required: true
+    from: '[a-zA-Z0-9]{40}'
+    generate: expression
+  - name: NAMESPACE
+    description: The Openshift namespace to be used.
+    displayName: namespace
+    required: true
+  - name: REGISTRY_HOST
+    description: The IP address or host of the Docker registry running inside Openshift
+    displayName: Registry Host
+    required: true
+    value: docker-registry.default.svc
+  - name: CRON_EXPRESSION
+    description: The cron expression that specifies when the cleanup script will run
+    displayName: Cron Expression
+    required: true
+  - name: GITHUB_USERNAME
+    description: The github username to cleanup
+    required: true
+  - name: GITHUB_ACCESS_TOKEN
+    description: The access token associated to the github username to cleanup
+    required: true
+objects:
+  - apiVersion: v1
+    kind: ImageStream
+    metadata:
+      name: github-cleanup
+    spec:
+      lookupPolicy:
+        local: true
+  - apiVersion: v1
+    kind: ImageStream
+    metadata:
+      name: runtime
+    spec:
+      tags:
+        - name: latest
+          from:
+            kind: DockerImage
+            name: 'bucharestgold/centos7-s2i-nodejs:10.x'
+  - apiVersion: v1
+    kind: BuildConfig
+    metadata:
+      name: github-cleanup
+    spec:
+      output:
+        to:
+          kind: ImageStreamTag
+          name: 'github-cleanup:latest'
+      postCommit: {}
+      resources: {}
+      source:
+        git:
+          uri: '${SOURCE_REPOSITORY_URL}'
+          ref: '${SOURCE_REPOSITORY_REF}'
+        type: Git
+      strategy:
+        type: Source
+        sourceStrategy:
+          from:
+            kind: ImageStreamTag
+            name: 'runtime:latest'
+          incremental: true
+      triggers:
+        - github:
+            secret: '${GITHUB_WEBHOOK_SECRET}'
+          type: GitHub
+        - type: ConfigChange
+        - imageChange: {}
+          type: ImageChange
+    status:
+      lastVersion: 0
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: github-secret
+      annotations:
+        template.openshift.io/base64-expose-username: "{.data['github_username']}"
+        template.openshift.io/base64-expose-token: "{.data['access_token']}"
+    stringData:
+      github_username: '${GITHUB_USERNAME}'
+      access_token: '${GITHUB_ACCESS_TOKEN}'
+  - apiVersion: batch/v2alpha1
+    kind: CronJob
+    metadata:
+      name: githun-cleanup
+    spec:
+      schedule: '${CRON_EXPRESSION}'
+      jobTemplate:
+        metadata:
+          labels:
+            job: githun-cleanup
+        spec:
+          backoffLimit: 1
+          template:
+            spec:
+              containers:
+              - name: githun-cleanup
+                image: ${REGISTRY_HOST}:5000/${NAMESPACE}/github-cleanup
+                env:
+                - name: GITHUB_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: github-secret
+                      key: github_username
+                - name: ACCESS_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: github-secret
+                      key: access_token
+              restartPolicy: Never


### PR DESCRIPTION
This PR adds all the necessary Openshift resources that will allow the script to run as a CronJob on an Openshift cluster.

This PR assumes that #2 will be implemented.

Furthermore, an example execution of that would apply the import template to an Openshift namespace and then apply it is:

```bash
oc new-project nodejs-example
oc apply -f .openshiftio/application.yml
oc new-app --template=github-cleanup -p SOURCE_REPOSITORY_URL=https://github.com/geoand/github-repo-cleanup-scripts -p SOURCE_REPOSITORY_REF=test -p GITHUB_USERNAME=geoand -p GITHUB_ACCESS_TOKEN=dummy -p NAMESPACE=$(oc project -q) -p REGISTRY_HOST=$(oc get service docker-registry -n default -o 'jsonpath={.spec.clusterIP}') -p CRON_EXPRESSION="0 0 * * SUN"
```